### PR TITLE
Execute only on google

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -17,14 +17,15 @@
   },
   "permissions": [
     "tabs",
-    "http://*/*",
-    "https://*/*"
+    "*://www.google.com/*"
   ],
   "content_scripts": [
     {
       "matches": [
-        "http://*/*",
-        "https://*/*"
+        "*://*/*"
+      ],
+      "include_globs": [
+        "*://www.google.*/*"
       ],
       "js": [
         "scripts/lib/jquery.min.js",

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -15,14 +15,15 @@
 	},
 	"permissions": [
 		"tabs",
-		"http://*/*",
-		"https://*/*"
+		"*://www.google.com/*"
 	],
 	"content_scripts": [
 		{
 			"matches": [
-				"http://*/*",
-				"https://*/*"
+				"*://*/*"
+			],
+			"include_globs": [
+				"*://www.google.*/*"
 			],
 			"js": [
 				"scripts/lib/jquery.min.js",


### PR DESCRIPTION
The '**manifest.json**' file has been edited so the script is only executed when browsing Google's websites. Before the changes, the extension was running on every page.

A few considerations to take into account:

# Changes

The change itself consists in adding **include_globs** to the manifest. You can't just match all google international domains (.co.uk, .us, .es, .fr, .de, etc), so it matches everything and then it filters with include_globs to match only the google domains. See [Match patterns and globs docs](https://developer.chrome.com/extensions/content_scripts#match-patterns-globs) for reference.

# Improves

Some match patterns have been changed to avoid specifying whether it is http or https. That is, instead of using two lines, e.g. "https://*" and "http://*", you can refer to both with the '*' character. See the official documentation [here](https://developer.chrome.com/extensions/match_patterns).

Note: As specified in the documentation: 

> If the scheme is *, then it matches either http or https, and not file, or ftp

So you don't have to worry about '*' matching other protocols.

# Security

Note that _\*://www.google.\*/\*_ will may execute the script on scam domains like "www.google.technology" (just made up). Seeing the type of script we're working on, I don't think it really matters, but I thought it worth mentioning.

Also I restricted permissions to _\*://www.google.com/\*_ instead of all domains.

# Testing

At first I thought adding tests to test the feature would be great but since the only test available is a generated file —likely included with the boilerplate— I didn't want to add any e2e test without even knowing how you would scaffold it and which tools: webdrivers, test frameworks, chrome APIs, etc. would you use.

Tip: You can check if it is working looking at logs. **'[bgvib] LOG START'** should appear only on Google's websites.